### PR TITLE
Remove unsafe code in verbose flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,19 +427,6 @@ impl<'cs, E: Engine, CS: ConstraintSystem<E>> ConstraintSystem<E> for &'cs mut C
     }
 }
 
-static mut VERBOSE_SWITCH: i8 = -1;
-
-use std::str::FromStr;
-use std::env;
-
 fn verbose_flag() -> bool {
-    unsafe {
-        if VERBOSE_SWITCH < 0 {
-            VERBOSE_SWITCH = FromStr::from_str(&env::var("BELLMAN_VERBOSE").unwrap_or(String::new())).unwrap_or(1);
-        }
-        match VERBOSE_SWITCH {
-            1 => true,
-            _ => false,
-        }
-    }
+    option_env!("BELLMAN_VERBOSE").unwrap_or("0") == "1"
 }


### PR DESCRIPTION
I'm not sure why the verbose flag is implemented using an unsafe block. Here's a proposal which might be simpler. Thoughts welcome as I may have missed something in the original intent.