### PR TITLE
fix cargo test --doc error

### DIFF
--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -40,7 +40,7 @@ use cfg_if;
 /// - double the highest accumulator enough times, add to the next one, double the result, add the next accumulator, continue
 /// 
 /// Demo why it works:
-/// ```
+/// ```text
 ///     a * G + b * H = (a_2 * (2^c)^2 + a_1 * (2^c)^1 + a_0) * G + (b_2 * (2^c)^2 + b_1 * (2^c)^1 + b_0) * H
 /// ```
 /// - make buckets over `0` labeled coefficients


### PR DESCRIPTION
Hello,

With newer cargo/rust version (here cargo 1.38.0-nightly), a simple cargo build fails:
```
running 1 test
test src/multiexp.rs - multiexp::multiexp_inner (line 43) ... FAILED

failures:

[...]
  |
3 | a * G + b * H = (a_2 * (2^c)^2 + a_1 * (2^c)^1 + a_0) * G + (b_2 * (2^c)^2 + b_1 * (2^c)^1 + b_0) * H
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ left-hand of expression not valid

error: aborting due to 17 previous errors

failures:
    src/multiexp.rs - multiexp::multiexp_inner (line 43)
```

That's because what's in "```" is supposed to be written in rust by default.
The fix makes explicit that it's not rust code.
