### PR TITLE
fix build for x86 arch

### DIFF
--- a/src/prefetch.rs
+++ b/src/prefetch.rs
@@ -40,7 +40,10 @@ cfg_if! {
             
 
             unsafe {
+                #[cfg(target_arch = "x86_64")]
                 _mm_prefetch(pointer as *const i8, core::arch::x86_64::_MM_HINT_T0);
+                #[cfg(target_arch = "x86")]
+                _mm_prefetch(pointer as *const i8, core::arch::x86::_MM_HINT_T0);
             }
         }
 
@@ -53,7 +56,10 @@ cfg_if! {
             
 
             unsafe {
+                #[cfg(target_arch = "x86_64")]
                 _mm_prefetch(pointer as *const i8, core::arch::x86_64::_MM_HINT_T1);
+                #[cfg(target_arch = "x86")]
+                _mm_prefetch(pointer as *const i8, core::arch::x86::_MM_HINT_T1);
             }
         }
 
@@ -66,7 +72,10 @@ cfg_if! {
             
 
             unsafe {
+                #[cfg(target_arch = "x86_64")]
                 _mm_prefetch(pointer as *const i8, core::arch::x86_64::_MM_HINT_T2);
+                #[cfg(target_arch = "x86")]
+                _mm_prefetch(pointer as *const i8, core::arch::x86::_MM_HINT_T2);
             }
         }
 
@@ -79,7 +88,10 @@ cfg_if! {
             
 
             unsafe {
+                #[cfg(target_arch = "x86_64")]
                 _mm_prefetch(reference as *const T as *const i8, core::arch::x86_64::_MM_HINT_T0);
+                #[cfg(target_arch = "x86")]
+                _mm_prefetch(reference as *const T as *const i8, core::arch::x86::_MM_HINT_T0);
             }
         }
 
@@ -92,7 +104,10 @@ cfg_if! {
             
 
             unsafe {
+                #[cfg(target_arch = "x86_64")]
                 _mm_prefetch(reference as *const T as *const i8, core::arch::x86_64::_MM_HINT_T1);
+                #[cfg(target_arch = "x86")]
+                _mm_prefetch(reference as *const T as *const i8, core::arch::x86::_MM_HINT_T1);
             }
         }
 
@@ -105,7 +120,10 @@ cfg_if! {
             
 
             unsafe {
+                #[cfg(target_arch = "x86_64")]
                 _mm_prefetch(reference as *const T as *const i8, core::arch::x86_64::_MM_HINT_T2);
+                #[cfg(target_arch = "x86")]
+                _mm_prefetch(reference as *const T as *const i8, core::arch::x86::_MM_HINT_T2);
             }
         }
     } else {


### PR DESCRIPTION
This PR fixes the build to the **i686-linux-android** architecture.

I tried to cross-compile the [zksync-crypto library](https://github.com/matter-labs/zksync/tree/master/js/zksync-crypto) for Android and I have the following errors:

```
$ cargo build --target i686-linux-android
   Compiling bellman_ce v0.3.2
error[E0433]: failed to resolve: could not find `x86_64` in `arch`
  --> src/prefetch.rs:43:64
   |
43 |                 _mm_prefetch(pointer as *const i8, core::arch::x86_64::_MM_HINT_T0);
   |                                                                ^^^^^^ could not find `x86_64` in `arch`

error[E0433]: failed to resolve: could not find `x86_64` in `arch`
  --> src/prefetch.rs:56:64
   |
56 |                 _mm_prefetch(pointer as *const i8, core::arch::x86_64::_MM_HINT_T1);
   |                                                                ^^^^^^ could not find `x86_64` in `arch`

error[E0433]: failed to resolve: could not find `x86_64` in `arch`
  --> src/prefetch.rs:69:64
   |
69 |                 _mm_prefetch(pointer as *const i8, core::arch::x86_64::_MM_HINT_T2);
   |                                                                ^^^^^^ could not find `x86_64` in `arch`

error[E0433]: failed to resolve: could not find `x86_64` in `arch`
  --> src/prefetch.rs:82:78
   |
82 |                 _mm_prefetch(reference as *const T as *const i8, core::arch::x86_64::_MM_HINT_T0);
   |                                                                              ^^^^^^ could not find `x86_64` in `arch`

error[E0433]: failed to resolve: could not find `x86_64` in `arch`
  --> src/prefetch.rs:95:78
   |
95 |                 _mm_prefetch(reference as *const T as *const i8, core::arch::x86_64::_MM_HINT_T1);
   |                                                                              ^^^^^^ could not find `x86_64` in `arch`

error[E0433]: failed to resolve: could not find `x86_64` in `arch`
   --> src/prefetch.rs:108:78
    |
108 |                 _mm_prefetch(reference as *const T as *const i8, core::arch::x86_64::_MM_HINT_T2);
    |                                                                              ^^^^^^ could not find `x86_64` in `arch`

error: aborting due to 6 previous errors

For more information about this error, try `rustc --explain E0433`.
error: could not compile `bellman_ce`.

To learn more, run the command again with --verbose.
```
