### PR TITLE
crates.io typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bellman "Community edition"
  
-Originally developed for ZCash, with extensions from us to make it a little more pleasant. Uses our "community edition" pairing for Ethereum's BN256 curve. Now published as `bellman_ce` on `crate.io` to allow ease of use.
+Originally developed for ZCash, with extensions from us to make it a little more pleasant. Uses our "community edition" pairing for Ethereum's BN256 curve. Now published as `bellman_ce` on `crates.io` to allow ease of use.
 
 ## Features
 


### PR DESCRIPTION
`crates.io` instead of `crate.io`.