### PR TITLE
fix crash & incorrect z_omega computation in prove step for target wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ crossbeam = {version = "0.7", optional = true}
 prefetch = {version = "0.2", optional = true}
 
 web-sys = {version = "0.3", optional = true, features = ["console", "Performance", "Window"]}
+instant = {version = "0.1", features = [ "wasm-bindgen" ], optional = true}
 
 tiny-keccak = {version = "1.5", optional = true}
 blake2-rfc = {version = "0.2.18", optional = true}
@@ -50,5 +51,5 @@ nolog = []
 plonk = ["lazy_static", "tiny-keccak", "blake2s_const"]
 # redshift = ["plonk", "rescue_hash", "poseidon_hash"]
 marlin = ["tiny-keccak", "blake2s_const"]
-wasm = ["web-sys"]
+wasm = ["web-sys", "instant"]
 asm = ["pairing/asm"]

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -536,7 +536,7 @@ fn test_field_element_multiplication_bn256() {
 
     let pool = Worker::new();
 
-    let start = std::time::Instant::now();
+    let start = crate::Instant::now();
 
     v1.mul_assign(&pool, &v2);
 
@@ -563,7 +563,7 @@ fn test_fft_bn256() {
 
     let pool = Worker::new();
 
-    let start = std::time::Instant::now();
+    let start = crate::Instant::now();
 
     v1.ifft(&pool);
 

--- a/src/gm17/generator.rs
+++ b/src/gm17/generator.rs
@@ -346,7 +346,7 @@ pub fn generate_parameters<E, C>(
     //     // Compute powers of tau
     //     if verbose {eprintln!("computing powers of tau...")};
 
-    //     let start = std::time::Instant::now();
+    //     let start = crate::Instant::now();
 
     //     {
     //         let domain = domain.as_mut();
@@ -384,7 +384,7 @@ pub fn generate_parameters<E, C>(
         // Compute powers of tau
         if verbose {eprintln!("computing powers of tau...")};
 
-        let start = std::time::Instant::now();
+        let start = crate::Instant::now();
 
         {
             let domain = domain.as_mut();
@@ -413,7 +413,7 @@ pub fn generate_parameters<E, C>(
 
         if verbose {eprintln!("computing the `G1^(gamma^2 * Z(t) * t^i)` query with multiple threads...")};
 
-        let start = std::time::Instant::now();
+        let start = crate::Instant::now();
 
         // Compute the H query with multiple threads
         worker.scope(gamma2_z_t_g1.len(), |scope, chunk| {
@@ -476,7 +476,7 @@ pub fn generate_parameters<E, C>(
 
     if verbose {eprintln!("using inverse FFT to convert to intepolation coefficients...")};
     
-    let start = std::time::Instant::now();
+    let start = crate::Instant::now();
 
     // Use inverse FFT to convert to intepolation coefficients
     domain.ifft(&worker);
@@ -486,7 +486,7 @@ pub fn generate_parameters<E, C>(
     if verbose {eprintln!("powers of tau evaluation in radix2 domain in {} s", start.elapsed().as_millis() as f64 / 1000.0)};
 
     if verbose {eprintln!("evaluating polynomials...")};
-    let start = std::time::Instant::now();
+    let start = crate::Instant::now();
 
     // overall strategy:
     // a_g1, a_g2, c_1_g1, c_2_g1 should be combined together by computing

--- a/src/kate_commitment/mod.rs
+++ b/src/kate_commitment/mod.rs
@@ -327,7 +327,7 @@ pub fn commit_using_monomials<E: Engine>(
 ) -> Result<E::G1Affine, SynthesisError> {
     println!("Committing coefficients");
 
-    use std::time::Instant;
+    use crate::Instant;
 
     let now = Instant::now();
 
@@ -363,7 +363,7 @@ pub fn commit_using_values<E: Engine>(
     println!("Committing values over domain");
     assert_eq!(poly.size(), crs.g1_bases.len());
 
-    use std::time::Instant;
+    use crate::Instant;
 
     let now = Instant::now();
 
@@ -1248,7 +1248,7 @@ pub(crate) mod test {
     #[ignore]
     fn test_multiexp_performance_on_large_data() {
         use crate::pairing::bn256::{Bn256, Fr};
-        use std::time::Instant;
+        use crate::Instant;
 
         let max_size = 1 << 26;
         let worker = Worker::new();
@@ -1300,7 +1300,7 @@ pub(crate) mod test {
     #[ignore]
     fn test_future_based_multiexp_performance_on_large_data() {
         use crate::pairing::bn256::{Bn256, Fr};
-        use std::time::Instant;
+        use crate::Instant;
         use std::sync::Arc;
 
         let max_size = 1 << 26;
@@ -1356,7 +1356,7 @@ pub(crate) mod test {
     #[ignore]
     fn test_long_naive_division() {
         use crate::pairing::bn256::{Bn256, Fr};
-        use std::time::Instant;
+        use crate::Instant;
 
         let max_size = 1 << 26;
         let worker = Worker::new();
@@ -1467,7 +1467,7 @@ pub(crate) mod test {
     }
 
     fn test_multiexps_inner<E: Engine>(max_size: usize, sizes: Vec<usize>, num_cpus: Vec<usize>) {
-        use std::time::Instant;
+        use crate::Instant;
         use std::sync::Arc;
 
         let worker = Worker::new();
@@ -1597,7 +1597,7 @@ pub(crate) mod test {
     // }
 
     // fn test_multiexps_over_window_sizes<E: Engine>(max_size: usize, sizes: Vec<usize>, num_cpus: Vec<usize>, windows: Vec<usize>) {
-    //     use std::time::Instant;
+    //     use crate::Instant;
     //     use std::sync::Arc;
 
     //     let worker = Worker::new();
@@ -1656,7 +1656,7 @@ pub(crate) mod test {
     // }
 
     // fn test_buffered_multiexp<E: Engine>(max_size: usize, sizes: Vec<usize>, num_cpus: Vec<usize>, windows: Vec<usize>, buffer_sizes: Vec<usize>) {
-    //     use std::time::Instant;
+    //     use crate::Instant;
     //     use std::sync::Arc;
 
     //     let worker = Worker::new();
@@ -1737,7 +1737,7 @@ pub(crate) mod test {
     //     use futures::executor::block_on;
     //     use futures::future::join_all;
 
-    //     use std::time::Instant;
+    //     use crate::Instant;
     //     use std::sync::Arc;
     //     use crate::source::FullDensity;
 
@@ -1833,7 +1833,7 @@ pub(crate) mod test {
     // }
 
     // fn test_l3_shared_multiexp<E: Engine>(max_parallel_jobs: usize, max_size: usize, cpus_per_job: usize, window: usize) {
-    //     use std::time::Instant;
+    //     use crate::Instant;
         
     //     let mut bases = vec![];
     //     let mut scalars = vec![];
@@ -1882,7 +1882,7 @@ pub(crate) mod test {
     // }
 
     fn test_future_based_multiexps_over_window_sizes<E: Engine>(max_size: usize, sizes: Vec<usize>, num_cpus: Vec<usize>, windows: Vec<usize>) {
-        use std::time::Instant;
+        use crate::Instant;
         use std::sync::Arc;
         use crate::source::FullDensity;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,3 +77,9 @@ cfg_if!{
         }
     }
 }
+
+#[cfg(not(feature = "wasm"))]
+pub use std::time::Instant;
+#[cfg(feature= "wasm")]
+pub use instant::Instant;
+

--- a/src/log.rs
+++ b/src/log.rs
@@ -78,12 +78,12 @@ cfg_if! {
         }
 
         pub struct Stopwatch {
-            start: std::time::Instant
+            start: crate::Instant
         }
 
         impl Stopwatch {
             pub fn new() -> Stopwatch {
-                Stopwatch { start: std::time::Instant::now() }
+                Stopwatch { start: crate::Instant::now() }
             }
 
             pub fn elapsed(&self) -> f64 {

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -942,7 +942,7 @@ mod test {
 
         use self::futures::executor::block_on;
 
-        let start = std::time::Instant::now();
+        let start = crate::Instant::now();
 
         let _fast = block_on(
             multiexp(

--- a/src/multiexp_experiments.rs
+++ b/src/multiexp_experiments.rs
@@ -3236,7 +3236,7 @@ mod test {
 
         use self::futures::executor::block_on;
 
-        let start = std::time::Instant::now();
+        let start = crate::Instant::now();
 
         let _fast = block_on(
             multiexp(
@@ -3270,7 +3270,7 @@ mod test {
 
         let pool = Worker::new();
 
-        let start = std::time::Instant::now();
+        let start = crate::Instant::now();
 
         let dense = dense_multiexp(
             &pool, &g, &v.clone()).unwrap();
@@ -3278,7 +3278,7 @@ mod test {
         let duration_ns = start.elapsed().as_nanos() as f64;
         println!("{} ns for dense for {} samples", duration_ns, SAMPLES);
 
-        let start = std::time::Instant::now();
+        let start = crate::Instant::now();
 
         let _map_reduce = map_reduce_multiexp_over_fixed_window(
             &pool,
@@ -3292,7 +3292,7 @@ mod test {
 
         // assert_eq!(dense, map_reduce);
 
-        let start = std::time::Instant::now();
+        let start = crate::Instant::now();
 
         let buffered = buffered_multiexp_over_fixed_window_and_buffer_size(
             &pool,
@@ -3309,7 +3309,7 @@ mod test {
 
         use self::futures::executor::block_on;
 
-        let start = std::time::Instant::now();
+        let start = crate::Instant::now();
 
         let sparse = block_on(
             multiexp(
@@ -3343,7 +3343,7 @@ mod test {
         println!("Done generating test points and scalars");
 
         let pool = Worker::new();
-        let start = std::time::Instant::now();
+        let start = crate::Instant::now();
 
         let _sparse = multiexp(
             &pool,
@@ -3371,7 +3371,7 @@ mod test {
         let g = (0..SAMPLES).map(|_| <Eng as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>();
 
         let pool = Worker::new();
-        let start = std::time::Instant::now();
+        let start = crate::Instant::now();
 
         let _dense = dense_multiexp_consume(
             &pool,

--- a/src/plonk/better_better_cs/cs_old.rs
+++ b/src/plonk/better_better_cs/cs_old.rs
@@ -1661,7 +1661,7 @@ pub fn prove_with_rescue_bn256<P: PlonkConstraintSystemParams<bn256::Bn256>, MG:
 
     let num_gates = assembly.n();
 
-    let start = std::time::Instant::now();
+    let start = crate::Instant::now();
 
     let (prover, first_state, first_message) = RedshiftProver::first_step(
         assembly, 
@@ -1831,7 +1831,7 @@ pub fn prove_with_poseidon_bn256<P: PlonkConstraintSystemParams<bn256::Bn256>, M
 
     let num_gates = assembly.n();
 
-    let start = std::time::Instant::now();
+    let start = crate::Instant::now();
 
     let (prover, first_state, first_message) = RedshiftProver::first_step(
         assembly, 
@@ -2001,7 +2001,7 @@ pub fn prove_with_hash_counting_bn256<P: PlonkConstraintSystemParams<bn256::Bn25
 
     let num_gates = assembly.n();
 
-    let start = std::time::Instant::now();
+    let start = crate::Instant::now();
 
     let (prover, first_state, first_message) = RedshiftProver::first_step(
         assembly, 

--- a/src/plonk/better_better_cs/trees/binary_tree.rs
+++ b/src/plonk/better_better_cs/trees/binary_tree.rs
@@ -21,7 +21,7 @@ pub struct BinaryTreeParams {
     pub values_per_leaf: usize
 }
 
-use std::time::Instant;
+use crate::Instant;
 
 impl<E: Engine, H: BinaryTreeHasher<E::Fr>> BinaryTree<E, H> {
     fn hash_into_leaf(tree_hasher: &H, values: &[E::Fr]) -> H::Output {

--- a/src/plonk/better_cs/prover/prove_steps.rs
+++ b/src/plonk/better_cs/prover/prove_steps.rs
@@ -40,7 +40,7 @@ impl<'a, F: PrimeField> PrecomputationsForPolynomial<'a, F> {
 
 pub(crate) fn get_precomputed_permutation_poly_lde_for_index<'a, E: Engine, CP: CTPrecomputations<E::Fr>>(
     index: usize,
-    domain_size: usize, 
+    domain_size: usize,
     setup: &SetupPolynomials<E, PlonkCsWidth4WithNextStepParams>,
     setup_precomputations: &Option< &'a SetupPolynomialsPrecomputations<E, PlonkCsWidth4WithNextStepParams> >,
     precomputed_omegas: &mut PrecomputedOmegas<E::Fr, CP>,
@@ -63,9 +63,9 @@ pub(crate) fn get_precomputed_permutation_poly_lde_for_index<'a, E: Engine, CP: 
         let p = setup.permutation_polynomials[index]
             .clone()
             .bitreversed_lde_using_bitreversed_ntt(
-                &worker, 
-                LDE_FACTOR, 
-                precomputed_omegas.as_ref(), 
+                &worker,
+                LDE_FACTOR,
+                precomputed_omegas.as_ref(),
                 &coset_factor
             )?;
 
@@ -75,7 +75,7 @@ pub(crate) fn get_precomputed_permutation_poly_lde_for_index<'a, E: Engine, CP: 
 
 pub(crate) fn get_precomputed_selector_lde_for_index<'a, E: Engine, CP: CTPrecomputations<E::Fr>>(
     index: usize,
-    domain_size: usize, 
+    domain_size: usize,
     setup: &SetupPolynomials<E, PlonkCsWidth4WithNextStepParams>,
     setup_precomputations: &Option< &'a SetupPolynomialsPrecomputations<E, PlonkCsWidth4WithNextStepParams> >,
     precomputed_omegas: &mut PrecomputedOmegas<E::Fr, CP>,
@@ -98,9 +98,9 @@ pub(crate) fn get_precomputed_selector_lde_for_index<'a, E: Engine, CP: CTPrecom
         let p = setup.selector_polynomials[index]
             .clone()
             .bitreversed_lde_using_bitreversed_ntt(
-                &worker, 
-                LDE_FACTOR, 
-                precomputed_omegas.as_ref(), 
+                &worker,
+                LDE_FACTOR,
+                precomputed_omegas.as_ref(),
                 &coset_factor
             )?;
 
@@ -110,7 +110,7 @@ pub(crate) fn get_precomputed_selector_lde_for_index<'a, E: Engine, CP: CTPrecom
 
 pub(crate) fn get_precomputed_next_step_selector_lde_for_index<'a, E: Engine, CP: CTPrecomputations<E::Fr>>(
     index: usize,
-    domain_size: usize, 
+    domain_size: usize,
     setup: &SetupPolynomials<E, PlonkCsWidth4WithNextStepParams>,
     setup_precomputations: &Option< &'a SetupPolynomialsPrecomputations<E, PlonkCsWidth4WithNextStepParams> >,
     precomputed_omegas: &mut PrecomputedOmegas<E::Fr, CP>,
@@ -133,9 +133,9 @@ pub(crate) fn get_precomputed_next_step_selector_lde_for_index<'a, E: Engine, CP
         let p = setup.next_step_selector_polynomials[index]
             .clone()
             .bitreversed_lde_using_bitreversed_ntt(
-                &worker, 
-                LDE_FACTOR, 
-                precomputed_omegas.as_ref(), 
+                &worker,
+                LDE_FACTOR,
+                precomputed_omegas.as_ref(),
                 &coset_factor
             )?;
 
@@ -144,7 +144,7 @@ pub(crate) fn get_precomputed_next_step_selector_lde_for_index<'a, E: Engine, CP
 }
 
 pub(crate) fn get_precomputed_x_lde<'a, E: Engine>(
-    domain_size: usize, 
+    domain_size: usize,
     setup_precomputations: &Option< &'a SetupPolynomialsPrecomputations<E, PlonkCsWidth4WithNextStepParams> >,
     worker: &Worker
 ) -> Result<PrecomputationsForPolynomial<'a, E::Fr>, SynthesisError> {
@@ -167,7 +167,7 @@ pub(crate) fn get_precomputed_x_lde<'a, E: Engine>(
 }
 
 pub(crate) fn get_precomputed_inverse_divisor<'a, E: Engine>(
-    domain_size: usize, 
+    domain_size: usize,
     setup_precomputations: &Option< &'a SetupPolynomialsPrecomputations<E, PlonkCsWidth4WithNextStepParams> >,
     worker: &Worker
 ) -> Result<PrecomputationsForPolynomial<'a, E::Fr>, SynthesisError> {
@@ -338,11 +338,11 @@ pub(crate) struct FifthProverMessage<E: Engine, P: PlonkConstraintSystemParams<E
 
 impl<E: Engine> ProverAssembly4WithNextStep<E> {
     pub(crate) fn first_step_with_lagrange_form_key(
-        self, 
-        worker: &Worker, 
-        crs_vals: &Crs<E, CrsForLagrangeForm>, 
+        self,
+        worker: &Worker,
+        crs_vals: &Crs<E, CrsForLagrangeForm>,
     ) -> Result<(
-        FirstPartialProverState<E, PlonkCsWidth4WithNextStepParams>, 
+        FirstPartialProverState<E, PlonkCsWidth4WithNextStepParams>,
         FirstProverMessage<E, PlonkCsWidth4WithNextStepParams>
     ), SynthesisError>
     {
@@ -365,7 +365,7 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
 
         let full_assignments = self.make_witness_polynomials()?;
 
-        // Commit wire polynomials 
+        // Commit wire polynomials
 
         let mut first_message = FirstProverMessage::<E, PlonkCsWidth4WithNextStepParams> {
             n: n,
@@ -378,8 +378,8 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
 
         for wire_poly in full_assignments.iter() {
             let commitment = commit_using_raw_values(
-                &wire_poly, 
-                &crs_vals, 
+                &wire_poly,
+                &crs_vals,
                 &worker
             )?;
 
@@ -408,12 +408,12 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
     }
 
     pub(crate) fn first_step_with_monomial_form_key<CPI: CTPrecomputations<E::Fr>>(
-        self, 
-        worker: &Worker, 
-        crs_mons: &Crs<E, CrsForMonomialForm>, 
+        self,
+        worker: &Worker,
+        crs_mons: &Crs<E, CrsForMonomialForm>,
         precomputed_omegas_inv: &mut PrecomputedOmegas<E::Fr, CPI>
     ) -> Result<(
-        FirstPartialProverState<E, PlonkCsWidth4WithNextStepParams>, 
+        FirstPartialProverState<E, PlonkCsWidth4WithNextStepParams>,
         FirstProverMessage<E, PlonkCsWidth4WithNextStepParams>
     ), SynthesisError>
     {
@@ -436,7 +436,7 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
 
         let full_assignments = self.make_witness_polynomials()?;
 
-        // Commit wire polynomials 
+        // Commit wire polynomials
 
         let mut first_message = FirstProverMessage::<E, PlonkCsWidth4WithNextStepParams> {
             n: n,
@@ -462,8 +462,8 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
                 .ifft_using_bitreversed_ntt(&worker, precomputed_omegas_inv.as_ref(), &E::Fr::one())?;
 
             let commitment = commit_using_monomials(
-                &as_coeffs, 
-                &crs_mons, 
+                &as_coeffs,
+                &crs_mons,
                 &worker
             )?;
 
@@ -498,7 +498,7 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
         first_state: FirstPartialProverState<E, PlonkCsWidth4WithNextStepParams>,
         first_verifier_message: FirstVerifierMessage<E, PlonkCsWidth4WithNextStepParams>,
         setup: &SetupPolynomials<E, PlonkCsWidth4WithNextStepParams>,
-        crs_mons: &Crs<E, CrsForMonomialForm>, 
+        crs_mons: &Crs<E, CrsForMonomialForm>,
         setup_precomputations: &Option< &SetupPolynomialsPrecomputations<E, PlonkCsWidth4WithNextStepParams> >,
         precomputed_omegas_inv: &mut PrecomputedOmegas<E::Fr, CPI>,
         worker: &Worker
@@ -523,7 +523,7 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
         let domain = Domain::new_for_size(required_domain_size as u64)?;
 
         let mut domain_elements = materialize_domain_elements_with_natural_enumeration(
-            &domain, 
+            &domain,
             &worker
         );
 
@@ -582,7 +582,7 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
 
         let z_den = {
             assert_eq!(
-                permutation_polynomials_values_of_size_n_minus_one.len(), 
+                permutation_polynomials_values_of_size_n_minus_one.len(),
                 grand_products_protos_with_gamma.len()
             );
             let mut grand_products_proto_it = grand_products_protos_with_gamma.into_iter();
@@ -593,7 +593,7 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
 
             for (mut p, perm) in grand_products_proto_it
                                             .zip(permutation_polys_it) {
-                // permutation polynomials 
+                // permutation polynomials
                 p.add_assign_scaled(&worker, perm.as_ref(), &beta);
                 z_2.mul_assign(&worker, &p);
             }
@@ -618,8 +618,8 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
         let z_in_monomial_form = z.ifft_using_bitreversed_ntt(&worker, precomputed_omegas_inv.as_ref(), &E::Fr::one())?;
 
         let z_commitment = commit_using_monomials(
-            &z_in_monomial_form, 
-            &crs_mons, 
+            &z_in_monomial_form,
+            &crs_mons,
             &worker
         )?;
 
@@ -646,7 +646,7 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
         second_state: SecondPartialProverState<E, PlonkCsWidth4WithNextStepParams>,
         second_verifier_message: SecondVerifierMessage<E, PlonkCsWidth4WithNextStepParams>,
         setup: &SetupPolynomials<E, PlonkCsWidth4WithNextStepParams>,
-        crs_mons: &Crs<E, CrsForMonomialForm>, 
+        crs_mons: &Crs<E, CrsForMonomialForm>,
         setup_precomputations: &Option< &SetupPolynomialsPrecomputations<E, PlonkCsWidth4WithNextStepParams> >,
         precomputed_omegas: &mut PrecomputedOmegas<E::Fr, CP>,
         precomputed_omegas_inv: &mut PrecomputedOmegas<E::Fr, CPI>,
@@ -661,7 +661,7 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
         // those are z(x*Omega) formally
         let mut z_shifted_in_monomial_form = z_in_monomial_form.clone();
         z_shifted_in_monomial_form.distribute_powers(&worker, z_in_monomial_form.omega);
-        
+
         // now we have to LDE everything and compute quotient polynomial
         // also to save on openings that we will have to do from the monomial form anyway
 
@@ -686,7 +686,7 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
 
         let mut witness_ldes_on_coset = vec![];
         let mut witness_next_ldes_on_coset = vec![];
- 
+
         for (idx, monomial) in witness_polys_in_monomial_form.iter().enumerate() {
             // this is D polynomial and we need to make next
             if idx == <PlonkCsWidth4WithNextStepParams as PlonkConstraintSystemParams<E>>::STATE_WIDTH - 1 {
@@ -694,9 +694,9 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
                 d_next.distribute_powers(&worker, d_next.omega);
 
                 let lde = d_next.bitreversed_lde_using_bitreversed_ntt(
-                    &worker, 
-                    LDE_FACTOR, 
-                    precomputed_omegas.as_ref(), 
+                    &worker,
+                    LDE_FACTOR,
+                    precomputed_omegas.as_ref(),
                     &coset_factor
                 )?;
 
@@ -704,9 +704,9 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
             }
 
             let lde = monomial.clone().bitreversed_lde_using_bitreversed_ntt(
-                &worker, 
-                LDE_FACTOR, 
-                precomputed_omegas.as_ref(), 
+                &worker,
+                LDE_FACTOR,
+                precomputed_omegas.as_ref(),
                 &coset_factor
             )?;
             witness_ldes_on_coset.push(lde);
@@ -736,9 +736,9 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
 
             // LDE
             let mut t_1 = inputs_poly.bitreversed_lde_using_bitreversed_ntt(
-                &worker, 
-                LDE_FACTOR, 
-                precomputed_omegas.as_ref(), 
+                &worker,
+                LDE_FACTOR,
+                precomputed_omegas.as_ref(),
                 &coset_factor
             )?;
 
@@ -747,9 +747,9 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
             // Q_A * A
             let mut tmp = witness_ldes_on_coset[0].clone();
             let a_selector = get_precomputed_selector_lde_for_index(
-                0, 
-                required_domain_size, 
-                &setup, 
+                0,
+                required_domain_size,
+                &setup,
                 &setup_precomputations,
                 precomputed_omegas,
                 &worker
@@ -761,9 +761,9 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
             // Q_B * B
             tmp.reuse_allocation(&witness_ldes_on_coset[1]);
             let b_selector = get_precomputed_selector_lde_for_index(
-                1, 
-                required_domain_size, 
-                &setup, 
+                1,
+                required_domain_size,
+                &setup,
                 &setup_precomputations,
                 precomputed_omegas,
                 &worker
@@ -775,9 +775,9 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
             // Q_C * C
             tmp.reuse_allocation(&witness_ldes_on_coset[2]);
             let c_selector = get_precomputed_selector_lde_for_index(
-                2, 
-                required_domain_size, 
-                &setup, 
+                2,
+                required_domain_size,
+                &setup,
                 &setup_precomputations,
                 precomputed_omegas,
                 &worker
@@ -789,9 +789,9 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
             // Q_D * D
             tmp.reuse_allocation(&witness_ldes_on_coset[3]);
             let d_selector = get_precomputed_selector_lde_for_index(
-                3, 
-                required_domain_size, 
-                &setup, 
+                3,
+                required_domain_size,
+                &setup,
                 &setup_precomputations,
                 precomputed_omegas,
                 &worker
@@ -804,9 +804,9 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
             tmp.reuse_allocation(&witness_ldes_on_coset[0]);
             tmp.mul_assign(&worker, &witness_ldes_on_coset[1]);
             let m_selector = get_precomputed_selector_lde_for_index(
-                4, 
-                required_domain_size, 
-                &setup, 
+                4,
+                required_domain_size,
+                &setup,
                 &setup_precomputations,
                 precomputed_omegas,
                 &worker
@@ -817,9 +817,9 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
 
             tmp.reuse_allocation(&witness_next_ldes_on_coset[0]);
             let d_next_selector = get_precomputed_next_step_selector_lde_for_index(
-                0, 
-                required_domain_size, 
-                &setup, 
+                0,
+                required_domain_size,
+                &setup,
                 &setup_precomputations,
                 precomputed_omegas,
                 &worker
@@ -837,18 +837,18 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
         // now compute the permutation argument
 
         let z_coset_lde_bitreversed = z_in_monomial_form.clone().bitreversed_lde_using_bitreversed_ntt(
-            &worker, 
-            LDE_FACTOR, 
-            precomputed_omegas.as_ref(), 
+            &worker,
+            LDE_FACTOR,
+            precomputed_omegas.as_ref(),
             &coset_factor
         )?;
 
         assert!(z_coset_lde_bitreversed.size() == required_domain_size*LDE_FACTOR);
 
         let z_shifted_coset_lde_bitreversed = z_shifted_in_monomial_form.bitreversed_lde_using_bitreversed_ntt(
-            &worker, 
-            LDE_FACTOR, 
-            precomputed_omegas.as_ref(), 
+            &worker,
+            LDE_FACTOR,
+            precomputed_omegas.as_ref(),
             &coset_factor
         )?;
 
@@ -859,7 +859,7 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
         );
 
         // For both Z_1 and Z_2 we first check for grand products
-        // z*(X)(A + beta*X + gamma)(B + beta*k_1*X + gamma)(C + beta*K_2*X + gamma) - 
+        // z*(X)(A + beta*X + gamma)(B + beta*k_1*X + gamma)(C + beta*K_2*X + gamma) -
         // - (A + beta*perm_a(X) + gamma)(B + beta*perm_b(X) + gamma)(C + beta*perm_c(X) + gamma)*Z(X*Omega)== 0
 
         // we use evaluations of the polynomial X and K_i * X on a large domain's coset
@@ -874,7 +874,7 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
             tmp.reuse_allocation(&witness_ldes_on_coset[0]);
             tmp.add_constant(&worker, &gamma);
             let x_precomp = get_precomputed_x_lde(
-                required_domain_size, 
+                required_domain_size,
                 setup_precomputations,
                 &worker
             )?;
@@ -903,9 +903,9 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
 
             for (idx, w) in witness_ldes_on_coset.iter().enumerate() {
                     let perm = get_precomputed_permutation_poly_lde_for_index(
-                        idx, 
-                        required_domain_size, 
-                        &setup, 
+                        idx,
+                        required_domain_size,
+                        &setup,
                         &setup_precomputations,
                         precomputed_omegas,
                         &worker
@@ -932,9 +932,9 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
             z_minus_one_by_l_0.sub_constant(&worker, &E::Fr::one());
 
             let l_coset_lde_bitreversed = l_0.bitreversed_lde_using_bitreversed_ntt(
-                &worker, 
-                LDE_FACTOR, 
-                precomputed_omegas.as_ref(), 
+                &worker,
+                LDE_FACTOR,
+                precomputed_omegas.as_ref(),
                 &coset_factor
             )?;
 
@@ -948,7 +948,7 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
         drop(tmp);
 
         let divisor_inversed = get_precomputed_inverse_divisor(
-            required_domain_size, 
+            required_domain_size,
             setup_precomputations,
             &worker
         )?;
@@ -979,8 +979,8 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
 
         for t_part in state.t_poly_parts.iter() {
             let t_part_commitment = commit_using_monomials(
-                &t_part, 
-                &crs_mons, 
+                &t_part,
+                &crs_mons,
                 &worker
             )?;
 
@@ -1092,7 +1092,7 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
 
             let mut factor = quotient_linearization_challenge;
             for (wire_at_z, non_residue) in state.wire_values_at_z.iter()
-                            .zip(Some(E::Fr::one()).iter().chain(&state.non_residues)) 
+                            .zip(Some(E::Fr::one()).iter().chain(&state.non_residues))
             {
                 let mut t = z;
                 t.mul_assign(&non_residue);
@@ -1176,9 +1176,9 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
                 tmp.mul_assign(&beta);
                 tmp.add_assign(&gamma);
                 tmp.add_assign(&w);
-                
+
                 z_part.mul_assign(&tmp);
-            }   
+            }
 
             // last poly value and gamma
             let mut tmp = gamma;
@@ -1190,7 +1190,7 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
             rhs.sub_assign(&z_part);
 
             quotient_linearization_challenge.mul_assign(&alpha);
-            
+
             // - L_0(z) * \alpha^2
 
             let mut l_0_at_z = evaluate_l0_at_point(required_domain_size as u64, z)?;
@@ -1222,7 +1222,7 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
         mut fourth_state: FourthPartialProverState<E, PlonkCsWidth4WithNextStepParams>,
         fourth_verifier_message: FourthVerifierMessage<E, PlonkCsWidth4WithNextStepParams>,
         setup: &SetupPolynomials<E, PlonkCsWidth4WithNextStepParams>,
-        crs_mons: &Crs<E, CrsForMonomialForm>, 
+        crs_mons: &Crs<E, CrsForMonomialForm>,
         worker: &Worker
     ) -> Result<FifthProverMessage<E, PlonkCsWidth4WithNextStepParams>, SynthesisError>
     {
@@ -1295,12 +1295,14 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
 
         worker.scope(polys.len(), |scope, chunk| {
             for p in polys.chunks_mut(chunk) {
-                scope.spawn(move |_| {
-                    let (poly, at) = &p[0];
-                    let at = *at;
-                    let result = divide_single::<E>(poly.as_ref(), at);
-                    p[0] = (Polynomial::from_coeffs(result).unwrap(), at);
-                });
+                for elem in p.iter_mut() {
+                    scope.spawn(move |_| {
+                        let (poly, at) = elem;
+                        let at = *at;
+                        let result = divide_single::<E>(poly.as_ref(), at);
+                        *elem = (Polynomial::from_coeffs(result).unwrap(), at);
+                    });
+                }
             }
         });
 
@@ -1308,13 +1310,13 @@ impl<E: Engine> ProverAssembly4WithNextStep<E> {
         let open_at_z = polys.pop().unwrap().0;
 
         let opening_at_z = commit_using_monomials(
-            &open_at_z, 
+            &open_at_z,
             &crs_mons,
             &worker
         )?;
 
         let opening_at_z_omega = commit_using_monomials(
-            &open_at_z_omega, 
+            &open_at_z_omega,
             &crs_mons,
             &worker
         )?;

--- a/src/plonk/blake2_const/benches/bench_multiprocess/src/main.rs
+++ b/src/plonk/blake2_const/benches/bench_multiprocess/src/main.rs
@@ -38,7 +38,7 @@ use std::io::prelude::*;
 use std::process;
 use std::ptr;
 use std::str;
-use std::time::Instant;
+use crate::Instant;
 
 const WORKERS: usize = 100;
 

--- a/src/plonk/commitments/transparent/fri/coset_combining_fri/fri.rs
+++ b/src/plonk/commitments/transparent/fri/coset_combining_fri/fri.rs
@@ -91,7 +91,7 @@ impl<F: PrimeField> FriIop<F> for CosetCombiningFriIop<F> {
     }
 }
 
-use std::time::Instant;
+use crate::Instant;
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct FRIProofPrototype<F: PrimeField, I: IopInstance<F>> {
@@ -396,7 +396,7 @@ mod test {
         use crate::plonk::transparent_engine::proth_engine::Fr;
         use crate::plonk::transparent_engine::PartialTwoBitReductionField;
         use crate::plonk::polynomials::*;
-        use std::time::Instant;
+        use crate::Instant;
         use crate::worker::*;
         use crate::plonk::commitments::transparent::utils::*;
         use crate::plonk::fft::cooley_tukey_ntt::{CTPrecomputations, BitReversedOmegas, OmegasInvBitreversed};
@@ -447,7 +447,7 @@ mod test {
         use crate::plonk::transparent_engine::proth_engine::Fr;
         use crate::plonk::transparent_engine::PartialTwoBitReductionField;
         use crate::plonk::polynomials::*;
-        use std::time::Instant;
+        use crate::Instant;
         use crate::worker::*;
         use crate::plonk::commitments::transparent::utils::*;
         use crate::plonk::fft::cooley_tukey_ntt::{CTPrecomputations, BitReversedOmegas, OmegasInvBitreversed};

--- a/src/plonk/commitments/transparent/fri/naive_fri/naive_fri.rs
+++ b/src/plonk/commitments/transparent/fri/naive_fri/naive_fri.rs
@@ -82,7 +82,7 @@ impl<F: PrimeField, I: IOP<F> > FriIop<F> for NaiveFriIop<F, I> {
     }
 }
 
-use std::time::Instant;
+use crate::Instant;
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct FRIProofPrototype<F: PrimeField, I: IOP<F>> {

--- a/src/plonk/commitments/transparent/iop/blake2s_trivial_iop.rs
+++ b/src/plonk/commitments/transparent/iop/blake2s_trivial_iop.rs
@@ -117,7 +117,7 @@ impl<F: PrimeField> Blake2sIopTree<F> {
     }
 }
 
-use std::time::Instant;
+use crate::Instant;
 
 impl<'a, F: PrimeField> IopTree<F> for Blake2sIopTree<F> {
     type Combiner = TrivialCombiner<F>;

--- a/src/plonk/commitments/transparent/iop/keccak_trivial_iop.rs
+++ b/src/plonk/commitments/transparent/iop/keccak_trivial_iop.rs
@@ -104,7 +104,7 @@ impl<F: PrimeField> KeccakIopTree<F> {
     }
 }
 
-use std::time::Instant;
+use crate::Instant;
 
 impl<'a, F: PrimeField> IopTree<F> for KeccakIopTree<F> {
     type Combiner = TrivialCombiner<F>;

--- a/src/plonk/commitments/transparent/iop_compiler/coset_combining_blake2s_tree.rs
+++ b/src/plonk/commitments/transparent/iop_compiler/coset_combining_blake2s_tree.rs
@@ -26,7 +26,7 @@ pub struct FriSpecificBlake2sTreeParams {
 //     }
 // }
 
-use std::time::Instant;
+use crate::Instant;
 
 impl<F: PrimeField> FriSpecificBlake2sTree<F> {
     const VALUE_BYTE_SIZE: usize = (((F::NUM_BITS as usize) / 64) + 1) * 8;

--- a/src/plonk/commitments/transparent/mod.rs
+++ b/src/plonk/commitments/transparent/mod.rs
@@ -66,7 +66,7 @@ impl<F: PrimeField, FRI: FriIop<F>> Clone for TransparentCommitterParameters<F, 
     }
 }
 
-use std::time::Instant;
+use crate::Instant;
 
 impl<
     F: PrimeField, 
@@ -686,7 +686,7 @@ mod test {
 
     #[test]
     fn test_large_transparent_commitment() {
-        use std::time::Instant;
+        use crate::Instant;
         use crate::pairing::bn256::{Bn256, Fr};
 
         let worker = Worker::new();

--- a/src/plonk/fft/cooley_tukey_ntt/mod.rs
+++ b/src/plonk/fft/cooley_tukey_ntt/mod.rs
@@ -519,7 +519,7 @@ mod test {
         use rand::{XorShiftRng, SeedableRng, Rand, Rng};
         use crate::plonk::transparent_engine::proth::Fr;
         use crate::plonk::polynomials::*;
-        use std::time::Instant;
+        use crate::Instant;
         use crate::worker::*;
         use crate::plonk::commitments::transparent::utils::*;
         use super::CTPrecomputations;
@@ -542,7 +542,7 @@ mod test {
         use rand::{XorShiftRng, SeedableRng, Rand, Rng};
         use crate::plonk::transparent_engine::proth::Fr;
         use crate::plonk::polynomials::*;
-        use std::time::Instant;
+        use crate::Instant;
         use super::*;
         use crate::worker::*;
         use crate::plonk::commitments::transparent::utils::*;
@@ -638,7 +638,7 @@ mod test {
         use rand::{XorShiftRng, SeedableRng, Rand, Rng};
         use crate::plonk::transparent_engine::proth::Fr;
         use crate::plonk::polynomials::*;
-        use std::time::Instant;
+        use crate::Instant;
         use super::*;
         use crate::worker::*;
         use crate::plonk::commitments::transparent::utils::*;

--- a/src/plonk/fft/cooley_tukey_ntt/partial_reduction.rs
+++ b/src/plonk/fft/cooley_tukey_ntt/partial_reduction.rs
@@ -489,7 +489,7 @@ mod test {
         use rand::{XorShiftRng, SeedableRng, Rand, Rng};
         use crate::plonk::transparent_engine::proth::Fr;
         use crate::plonk::polynomials::*;
-        use std::time::Instant;
+        use crate::Instant;
         use super::*;
         use crate::worker::*;
         use crate::plonk::commitments::transparent::utils::*;
@@ -631,7 +631,7 @@ mod test {
         use rand::{XorShiftRng, SeedableRng, Rand, Rng};
         use crate::plonk::transparent_engine::proth::Fr;
         use crate::plonk::polynomials::*;
-        use std::time::Instant;
+        use crate::Instant;
         use super::*;
         use crate::worker::*;
         use crate::plonk::commitments::transparent::utils::*;

--- a/src/plonk/fft/lde.rs
+++ b/src/plonk/fft/lde.rs
@@ -205,7 +205,7 @@ pub(crate) fn parallel_lde<F: PrimeField>(
 //     use crate::experiments::vdf::Fr;
 //     use crate::domains::Domain;
 //     use crate::fft::multicore::Worker;
-//     use std::time::Instant;
+//     use crate::Instant;
 
 //     let worker = Worker::new();
 
@@ -252,7 +252,7 @@ pub(crate) fn parallel_lde<F: PrimeField>(
 //     use ff::Field;
 //     use crate::experiments::vdf::Fr;
 //     use crate::domains::Domain;
-//     use std::time::Instant;
+//     use crate::Instant;
 
 //     let mut coeffs = (0..BASE).map(|_| Fr::rand(rng)).collect::<Vec<_>>();
 
@@ -289,7 +289,7 @@ pub(crate) fn parallel_lde<F: PrimeField>(
 //     use ff::Field;
 //     use crate::experiments::vdf::Fr;
 //     use crate::domains::Domain;
-//     use std::time::Instant;
+//     use crate::Instant;
 
 //     let mut coeffs = (0..BASE).map(|_| Fr::rand(rng)).collect::<Vec<_>>();
 
@@ -328,7 +328,7 @@ pub(crate) fn parallel_lde<F: PrimeField>(
 //     use crate::domains::Domain;
 //     use crate::fft::multicore::Worker;
 //     use crate::polynomials::Polynomial;
-//     use std::time::Instant;
+//     use crate::Instant;
 
 //     let worker = Worker::new();
 

--- a/src/plonk/fft/prefetch_lde.rs
+++ b/src/plonk/fft/prefetch_lde.rs
@@ -294,7 +294,7 @@ pub(crate) fn parallel_lde<F: PrimeField>(
 //     use crate::experiments::vdf::Fr;
 //     use crate::domains::Domain;
 //     use crate::fft::multicore::Worker;
-//     use std::time::Instant;
+//     use crate::Instant;
 
 //     let worker = Worker::new();
 
@@ -341,7 +341,7 @@ pub(crate) fn parallel_lde<F: PrimeField>(
 //     use ff::Field;
 //     use crate::experiments::vdf::Fr;
 //     use crate::domains::Domain;
-//     use std::time::Instant;
+//     use crate::Instant;
 
 //     let mut coeffs = (0..BASE).map(|_| Fr::rand(rng)).collect::<Vec<_>>();
 
@@ -378,7 +378,7 @@ pub(crate) fn parallel_lde<F: PrimeField>(
 //     use ff::Field;
 //     use crate::experiments::vdf::Fr;
 //     use crate::domains::Domain;
-//     use std::time::Instant;
+//     use crate::Instant;
 
 //     let mut coeffs = (0..BASE).map(|_| Fr::rand(rng)).collect::<Vec<_>>();
 
@@ -417,7 +417,7 @@ pub(crate) fn parallel_lde<F: PrimeField>(
 //     use crate::domains::Domain;
 //     use crate::fft::multicore::Worker;
 //     use crate::polynomials::Polynomial;
-//     use std::time::Instant;
+//     use crate::Instant;
 
 //     let worker = Worker::new();
 

--- a/src/plonk/fft/recursive_fft.rs
+++ b/src/plonk/fft/recursive_fft.rs
@@ -184,7 +184,7 @@ fn test_large_fft_speed() {
     use crate::domains::Domain;
     use crate::fft::multicore::Worker;
     use crate::polynomials::Polynomial;
-    use std::time::Instant;
+    use crate::Instant;
 
     let worker = Worker::new();
 

--- a/src/plonk/fft/recursive_lde.rs
+++ b/src/plonk/fft/recursive_lde.rs
@@ -163,7 +163,7 @@ fn test_small_recursive_lde() {
     use crate::experiments::vdf::Fr;
     use crate::domains::Domain;
     use crate::fft::multicore::Worker;
-    use std::time::Instant;
+    use crate::Instant;
 
     let worker = Worker::new();
 
@@ -200,7 +200,7 @@ fn test_large_recursive_lde() {
     use crate::domains::Domain;
     use crate::fft::multicore::Worker;
     use crate::polynomials::Polynomial;
-    use std::time::Instant;
+    use crate::Instant;
 
     let worker = Worker::new();
 

--- a/src/plonk/fft/with_precomputation/lde.rs
+++ b/src/plonk/fft/with_precomputation/lde.rs
@@ -205,7 +205,7 @@ pub(crate) fn parallel_lde<F: PrimeField>(
 //     use crate::experiments::vdf::Fr;
 //     use crate::domains::Domain;
 //     use crate::fft::multicore::Worker;
-//     use std::time::Instant;
+//     use crate::Instant;
 
 //     let worker = Worker::new();
 
@@ -252,7 +252,7 @@ pub(crate) fn parallel_lde<F: PrimeField>(
 //     use ff::Field;
 //     use crate::experiments::vdf::Fr;
 //     use crate::domains::Domain;
-//     use std::time::Instant;
+//     use crate::Instant;
 
 //     let mut coeffs = (0..BASE).map(|_| Fr::rand(rng)).collect::<Vec<_>>();
 
@@ -289,7 +289,7 @@ pub(crate) fn parallel_lde<F: PrimeField>(
 //     use ff::Field;
 //     use crate::experiments::vdf::Fr;
 //     use crate::domains::Domain;
-//     use std::time::Instant;
+//     use crate::Instant;
 
 //     let mut coeffs = (0..BASE).map(|_| Fr::rand(rng)).collect::<Vec<_>>();
 
@@ -328,7 +328,7 @@ pub(crate) fn parallel_lde<F: PrimeField>(
 //     use crate::domains::Domain;
 //     use crate::fft::multicore::Worker;
 //     use crate::polynomials::Polynomial;
-//     use std::time::Instant;
+//     use crate::Instant;
 
 //     let worker = Worker::new();
 

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -141,7 +141,7 @@ pub fn prove_native_by_steps<E: Engine, C: crate::plonk::better_cs::cs::Circuit<
     use crate::plonk::better_cs::utils::{commit_point_as_xy};
     use crate::plonk::better_cs::prover::prove_steps::{FirstVerifierMessage, SecondVerifierMessage, ThirdVerifierMessage, FourthVerifierMessage};
 
-    use std::time::Instant;
+    use crate::Instant;
 
     let mut assembly = self::better_cs::prover::ProverAssembly::new_with_size_hints(setup.num_inputs, setup.n);
 
@@ -374,7 +374,7 @@ pub fn prove<E: Engine, C: crate::Circuit<E>, T: Transcript<E::Fr>>(
     let omegas_bitreversed = BitReversedOmegas::<E::Fr>::new_for_domain_size(size.next_power_of_two());
     let omegas_inv_bitreversed = <OmegasInvBitreversed::<E::Fr> as CTPrecomputations::<E::Fr>>::new_for_domain_size(size.next_power_of_two());
 
-    use std::time::Instant;
+    use crate::Instant;
     let now = Instant::now();
     let proof = assembly.prove::<T, _, _>(
         &worker,
@@ -425,7 +425,7 @@ pub fn prove_from_recomputations<
 
     let worker = Worker::new();
 
-    use std::time::Instant;
+    use crate::Instant;
     let now = Instant::now();
     let proof = assembly.prove::<T, _, _>(
         &worker,

--- a/src/plonk/plonk/prover.rs
+++ b/src/plonk/plonk/prover.rs
@@ -1789,7 +1789,7 @@ mod test {
         type Transcr = Blake2sTranscript<Fr>;
         type Eng = Bls12;
 
-        use std::time::Instant;
+        use crate::Instant;
 
         use crate::plonk::fft::cooley_tukey_ntt::*;
         use crate::plonk::commitments::transparent::fri::coset_combining_fri::precomputation::*;
@@ -1925,7 +1925,7 @@ mod test {
         type Transcr = Blake2sTranscript<Fr>;
         type Eng = Bn256;
 
-        use std::time::Instant;
+        use crate::Instant;
 
         use crate::plonk::fft::cooley_tukey_ntt::*;
         use crate::plonk::commitments::transparent::fri::coset_combining_fri::precomputation::*;

--- a/src/plonk/polynomials/mod.rs
+++ b/src/plonk/polynomials/mod.rs
@@ -706,7 +706,7 @@ impl<F: PrimeField> Polynomial<F, Coefficients> {
         factor: usize,
         precomputed_omegas: &P
     ) -> Result<Polynomial<F, Values>, SynthesisError> {
-        use std::time::Instant;
+        use crate::Instant;
         debug_assert!(self.coeffs.len().is_power_of_two());
         debug_assert_eq!(self.size(), precomputed_omegas.domain_size());
         
@@ -2548,7 +2548,7 @@ mod test {
             for cpus in vec![4, 8, 16, 32] {
             // for cpus in vec![16, 24, 32] {
 
-                use std::time::Instant;
+                use crate::Instant;
 
                 let subworker = Worker::new_with_cpus(cpus);
 
@@ -2593,7 +2593,7 @@ mod test {
             for cpus in vec![4, 8, 16, 32] {
             // for cpus in vec![16, 24, 32] {
 
-                use std::time::Instant;
+                use crate::Instant;
 
                 let subworker = Worker::new_with_cpus(cpus);
 

--- a/src/plonk/redshift/prover.rs
+++ b/src/plonk/redshift/prover.rs
@@ -1724,7 +1724,7 @@ mod test {
         use crate::plonk::commitments::transparent::iop_compiler::*;
         use crate::plonk::commitments::transparent::iop_compiler::coset_combining_blake2s_tree::*;
 
-        use std::time::Instant;
+        use crate::Instant;
 
         let log_2_rate = 4;
         let rate = 1 << log_2_rate;

--- a/src/plonk/transparent_engine/mod.rs
+++ b/src/plonk/transparent_engine/mod.rs
@@ -63,7 +63,7 @@ mod test {
         use super::Fr as FrMontNaive;
         use super::proth::Fr as FrOptimized;
         use crate::plonk::polynomials::*;
-        use std::time::Instant;
+        use crate::Instant;
         use crate::worker::*;
         use crate::plonk::commitments::transparent::utils::*;
 
@@ -133,7 +133,7 @@ mod test {
         use super::Fr as FrMontNaive;
         use super::proth::Fr as FrOptimized;
         use crate::plonk::polynomials::*;
-        use std::time::Instant;
+        use crate::Instant;
         use crate::worker::*;
         use crate::plonk::commitments::transparent::utils::*;
         use crate::plonk::fft::fft::best_fft;
@@ -184,7 +184,7 @@ mod test {
         use super::Fr as FrMontNaive;
         use super::proth::Fr as FrOptimized;
         use crate::plonk::polynomials::*;
-        use std::time::Instant;
+        use crate::Instant;
         use crate::worker::*;
         use crate::plonk::commitments::transparent::utils::*;
         use crate::plonk::fft::with_precomputation::FftPrecomputations;
@@ -230,7 +230,7 @@ mod test {
         use rand::{XorShiftRng, SeedableRng, Rand, Rng};
         use super::proth::Fr as Fr;
         use crate::plonk::polynomials::*;
-        use std::time::Instant;
+        use crate::Instant;
         use crate::worker::*;
         use crate::plonk::commitments::transparent::utils::*;
         use crate::plonk::fft::cooley_tukey_ntt::{CTPrecomputations, BitReversedOmegas};
@@ -280,7 +280,7 @@ mod test {
     //     use rand::{XorShiftRng, SeedableRng, Rand, Rng};
     //     use super::proth::Fr as Fr;
     //     use crate::plonk::polynomials::*;
-    //     use std::time::Instant;
+    //     use crate::Instant;
     //     use crate::worker::*;
     //     use crate::plonk::commitments::transparent::utils::*;
     //     use crate::plonk::fft::cooley_tukey_ntt::{CTPrecomputations, BitReversedOmegas};
@@ -360,7 +360,7 @@ mod test {
         use super::proth::Fr as Fr;
         use super::PartialTwoBitReductionField;
         use crate::plonk::polynomials::*;
-        use std::time::Instant;
+        use crate::Instant;
         use crate::worker::*;
         use crate::plonk::commitments::transparent::utils::*;
         use crate::plonk::fft::cooley_tukey_ntt::{CTPrecomputations, BitReversedOmegas};
@@ -409,7 +409,7 @@ mod test {
         use rand::{XorShiftRng, SeedableRng, Rand, Rng};
         use super::proth::Fr as Fr;
         use crate::plonk::polynomials::*;
-        use std::time::Instant;
+        use crate::Instant;
         use crate::worker::*;
         use crate::plonk::commitments::transparent::utils::*;
         use crate::plonk::fft::cooley_tukey_ntt::{CTPrecomputations, BitReversedOmegas, best_ct_ntt};

--- a/src/plonk/verifier/mod.rs
+++ b/src/plonk/verifier/mod.rs
@@ -978,7 +978,7 @@ mod test {
         use crate::plonk::commitments::transparent::*;
         use crate::plonk::tester::*;
 
-        use std::time::Instant;
+        use crate::Instant;
 
         type Iop = TrivialBlake2sIOP<Fr>;
         type Fri = NaiveFriIop<Fr, Iop>;
@@ -1054,7 +1054,7 @@ mod test {
     //     use crate::plonk::commitments::*;
     //     use crate::plonk::commitments::transparent::*;
 
-    //     use std::time::Instant;
+    //     use crate::Instant;
 
     //     type Iop = TrivialKeccakIOP<Fr>;
     //     type Fri = NaiveFriIop<Fr, Iop>;
@@ -1137,7 +1137,7 @@ mod test {
         println!("Done generating test points and scalars");
 
         let pool = Worker::new();
-        let start = std::time::Instant::now();
+        let start = crate::Instant::now();
 
         let _sparse = multiexp(
             &pool,
@@ -1165,7 +1165,7 @@ mod test {
         use crate::plonk::commitments::transparent::*;
         use crate::plonk::tester::*;
 
-        use std::time::Instant;
+        use crate::Instant;
 
         type Iop = TrivialBlake2sIOP<Fr>;
         type Fri = NaiveFriIop<Fr, Iop>;
@@ -1246,7 +1246,7 @@ mod test {
         use crate::plonk::commitments::transparent::*;
         use crate::plonk::tester::*;
 
-        use std::time::Instant;
+        use crate::Instant;
 
         type Iop = TrivialBlake2sIOP<Fr>;
         type Fri = NaiveFriIop<Fr, Iop>;
@@ -1381,7 +1381,7 @@ mod test {
         use crate::pairing::bn256::Fr;
         use crate::pairing::ff::ScalarEngine;
         use crate::pairing::CurveProjective;
-        use std::time::Instant;
+        use crate::Instant;
         use crate::worker::*;
         use crate::plonk::commitments::transparent::utils::*;
 

--- a/src/sonic/helped/generator.rs
+++ b/src/sonic/helped/generator.rs
@@ -428,7 +428,7 @@ pub fn generate_srs<E: Engine>(
         // Compute powers of tau
         if verbose {eprintln!("computing powers of x...")};
 
-        let start = std::time::Instant::now();
+        let start = crate::Instant::now();
 
         {
             worker.scope(d, |scope, chunk| {
@@ -540,7 +540,7 @@ pub fn generate_srs<E: Engine>(
         });
     }
 
-    let start = std::time::Instant::now();
+    let start = crate::Instant::now();
 
     // Evaluate for positive powers.
     eval(

--- a/src/sonic/helped/helper.rs
+++ b/src/sonic/helped/helper.rs
@@ -132,7 +132,7 @@ pub fn create_aggregate_on_srs_using_information<E: Engine, C: Circuit<E>, S: Sy
         value
     }
 
-    use std::time::Instant;
+    use crate::Instant;
     let start = Instant::now();
 
     let mut c_openings = vec![];

--- a/src/sonic/unhelped/aggregate.rs
+++ b/src/sonic/unhelped/aggregate.rs
@@ -79,7 +79,7 @@ pub fn create_aggregate_on_srs_using_information<E: Engine, C: Circuit<E>, S: Sy
     q: usize,
 ) -> SuccinctAggregate<E>
 {
-    use std::time::Instant;
+    use crate::Instant;
     let start = Instant::now();
     // take few proofs that are to be evaluated at some y_i and make an aggregate from them
     let mut transcript = Transcript::new(&[]);
@@ -134,8 +134,8 @@ pub fn create_aggregate_on_srs_using_information<E: Engine, C: Circuit<E>, S: Sy
 
     println!("Commit and opening of for s(z, w) taken {:?}", start.elapsed());
 
-    // now we need signature of correct computation. For this purpose 
-    // verifier already knows specialized SRS, so we can just commit to 
+    // now we need signature of correct computation. For this purpose
+    // verifier already knows specialized SRS, so we can just commit to
     // s1 and s2 parts of such signature to get `w` and later open at this point!
 
     // Commit!
@@ -158,10 +158,10 @@ pub fn create_aggregate_on_srs_using_information<E: Engine, C: Circuit<E>, S: Sy
     let start = Instant::now();
 
     let signature = PermutationArgument::make_signature(
-        non_permuted_coeffs, 
-        permutations, 
-        w, 
-        z, 
+        non_permuted_coeffs,
+        permutations,
+        w,
+        z,
         &srs,
     );
 

--- a/src/sonic/util.rs
+++ b/src/sonic/util.rs
@@ -125,7 +125,7 @@ pub fn polynomial_commitment_opening<
     {
         // let poly = parallel_kate_divison::<E, _>(polynomial_coefficients, point);
 
-        // use std::time::Instant;
+        // use crate::Instant;
         // let start = Instant::now();
 
         let poly = kate_divison(
@@ -294,7 +294,7 @@ pub fn mut_distribute_consequitive_powers<'a, F: Field> (
 //     use crate::worker::Worker;
 //     use crate::multiexp::dense_multiexp;
 
-//     use std::time::Instant;
+//     use crate::Instant;
 //     let start = Instant::now();
 
 //     let s: Vec<<G::Scalar as PrimeField>::Repr> = s.into_iter().map(|e| e.into_repr()).collect::<Vec<_>>();
@@ -347,7 +347,7 @@ where
 
     let pool = Worker::new();
 
-    // use std::time::Instant;
+    // use crate::Instant;
     // let start = Instant::now();
 
     let result = multiexp(


### PR DESCRIPTION
We are implementing the Web&NodeJS bellman prover [plonkjs](https://github.com/0xEigenLabs/plonkjs), and met the same issue as #38. 

## Issue and fix
After diving into the difference between the two proof of wasm and multicore, we found that the code block in https://github.com/matter-labs/bellman/blob/beta/src/plonk/better_cs/prover/prove_steps.rs#L1296 is not correctly implemented.  

Explain it with a simple example as below: 

```
fn main() {
    let mut polys = vec![(1, 2), (5, 6), (20, 30)];
    let count = 1;
    for p in polys.chunks_mut(2) {
        println!("p : {:?}", p);      // **p : [(1, 2), (5, 6)];** p : [(20, 30)] 
        for elem in p.iter_mut() {
            let (m, n) = elem;
            println!("m, n = {} {}", m, n);  // **m, n = 1 2;** m, n = 5 6
            *elem = ((*m) + (*n), *n);
            println!("updated tuple {:?}", elem); // **updated tuple (3, 2), updated tuple (11, 6);**  updated tuple (50, 30)
        }
    }
}
```
In bellmen's current implementation,  the Scope limits the task for each thread, but line 6 above is missed: 

```
worker.scope(polys.len(), |scope, chunk| {
            for p in polys.chunks_mut(chunk) {
                scope.spawn(move |_| {
                    let (poly, at) = &p[0];
                    let at = *at;
                    let result = divide_single::<E>(poly.as_ref(), at);
                    p[0] = (Polynomial::from_coeffs(result).unwrap(), at);
                });
            }
        });
```
For feature wasm, the p is a chunk with 2 tuples(with `polys.lens()` elements in polys, which means all the elements),  and each time it just calculates the poly_to_divide_at_z, ignoring the poly_to_divide_at_z_omega.

For feature multicore, it seems to work as expected each time, actually, it did.  Because the code below 

```
      let chunk_size = self.get_chunk_size(elements);

     crossbeam::scope(|scope| {
            f(scope, chunk_size)
        }).expect("must run")
    }

```
digests the whole polys array, and splits it into chunks of chunk_size=1. The  get_chunk_size always returns 1.

So the fix here is to put the number of chunk_size elements in scope, as we expected. 

Another fix for wasm is due to the import of std::time::Instant, which raises crash in wasm.   we can replace it with https://github.com/sebcrozet/instant. 

## Test 

Just use the repo in #38 and modify the bellman's git to https://github.com/0xEigenLabs/bellman at branch beta. you can check out both proofs are valid. 

@shamatar Plz check out our fix.
@weijiekoh Feel free to verify the fix for issue #38. 
