### PR TITLE
`Proof` and `VerificationKey` structs: Make `_marker` fields public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 target
 Cargo.lock
 pkg

--- a/src/plonk/better_cs/keys.rs
+++ b/src/plonk/better_cs/keys.rs
@@ -598,7 +598,7 @@ pub struct Proof<E: Engine, P: PlonkConstraintSystemParams<E>> {
     pub opening_at_z_proof: E::G1Affine,
     pub opening_at_z_omega_proof: E::G1Affine,
 
-    pub(crate) _marker: std::marker::PhantomData<P>,
+    pub _marker: std::marker::PhantomData<P>,
 }
 
 impl<E: Engine, P: PlonkConstraintSystemParams<E>> Proof<E, P> {
@@ -780,7 +780,7 @@ pub struct VerificationKey<E: Engine, P: PlonkConstraintSystemParams<E>> {
 
     pub g2_elements: [E::G2Affine; 2],
 
-    pub(crate) _marker: std::marker::PhantomData<P>,
+    pub _marker: std::marker::PhantomData<P>,
 }
 
 impl<E: Engine, P: PlonkConstraintSystemParams<E>> VerificationKey<E, P> {


### PR DESCRIPTION
This is needed so that proofs and verification keys can be instantiated from other crates (e.g. in ZoKrates).

I also added `.vscode` to `.gitignore`.